### PR TITLE
Feature: Inspect

### DIFF
--- a/finny/Cargo.toml
+++ b/finny/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "finny"
-version = "0.1.1"
+version = "0.2.0"
 authors = ["Rudi Benkovic <rudi.benkovic@gmail.com>"]
 edition = "2018"
 repository = "https://github.com/hashmismatch/finny.rs"

--- a/finny/Cargo.toml
+++ b/finny/Cargo.toml
@@ -12,7 +12,7 @@ readme = "../README.md"
 
 [dependencies]
 derive_more = "0.99.11"
-finny_derive = { path = "../finny_derive", version = "0.1.0" }
+finny_derive = { path = "../finny_derive", version = "0.2.0" }
 arraydeque = { version = "0.4", default-features = false }
 slog = { version = "2.7.0", optional = true }
 

--- a/finny/Cargo.toml
+++ b/finny/Cargo.toml
@@ -14,7 +14,9 @@ readme = "../README.md"
 derive_more = "0.99.11"
 finny_derive = { path = "../finny_derive", version = "0.1.0" }
 arraydeque = { version = "0.4", default-features = false }
+slog = { version = "2.7.0", optional = true }
 
 [features]
-default = ["std"]
+default = ["std", "inspect_slog"]
 std = ["arraydeque/std"]
+inspect_slog = ["slog"]

--- a/finny/src/decl/fsm.rs
+++ b/finny/src/decl/fsm.rs
@@ -29,6 +29,11 @@ impl<TFsm, TContext> FsmBuilder<TFsm, TContext>
 
 	}
 
+	/// Require the `Debug` trait on the Events.
+	pub fn events_debug(&mut self) {
+		
+	}
+
 	/// Adds some information about a state.
 	pub fn state<TState>(&mut self) -> FsmStateBuilder<TFsm, TContext, TState> {
 		FsmStateBuilder {

--- a/finny/src/fsm/events.rs
+++ b/finny/src/fsm/events.rs
@@ -15,10 +15,23 @@ impl<E> From<E> for FsmEvent<E> {
     }
 }
 
+impl<E> Debug for FsmEvent<E> where E: Debug {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        match self {
+            FsmEvent::Start => f.write_str("Fsm::Start"),
+            FsmEvent::Stop => f.write_str("Fsm::Stop"),
+            FsmEvent::Event(ev) => ev.fmt(f)
+        }
+    }
+}
+
+pub type FsmRegionId = usize;
+
 /// The context that is given to all of the guards and actions.
 pub struct EventContext<'a, TFsm, Q> where TFsm: FsmBackend, Q: FsmEventQueue<TFsm> {
     pub context: &'a mut TFsm::Context,
-    pub queue: &'a mut Q
+    pub queue: &'a mut Q,
+    pub region: FsmRegionId
 }
 
 impl<'a, TFsm, Q> Deref for EventContext<'a, TFsm, Q> where TFsm: FsmBackend, Q: FsmEventQueue<TFsm>

--- a/finny/src/fsm/fsm_factory.rs
+++ b/finny/src/fsm/fsm_factory.rs
@@ -1,4 +1,4 @@
-use crate::{FsmBackend, FsmBackendImpl, FsmEventQueue, FsmFrontend, FsmResult};
+use crate::{FsmBackend, FsmBackendImpl, FsmEventQueue, FsmFrontend, FsmResult, Inspect, InspectNull};
 
 #[cfg(feature="std")]
 use crate::FsmEventQueueVec;
@@ -8,23 +8,25 @@ pub trait FsmFactory {
     type Fsm: FsmBackend;
 
     /// Build a new frontend for the FSM with all the environmental services provided by the caller.
-    fn new_with<Q>(context: <Self::Fsm as FsmBackend>::Context, queue: Q) -> FsmResult<FsmFrontend<Self::Fsm, Q>>
-        where Q: FsmEventQueue<Self::Fsm>
+    fn new_with<Q, I>(context: <Self::Fsm as FsmBackend>::Context, queue: Q, inspect: I) -> FsmResult<FsmFrontend<Self::Fsm, Q, I>>
+        where Q: FsmEventQueue<Self::Fsm>, I: Inspect<Self::Fsm>
     {
         let frontend = FsmFrontend {
             queue,
+            inspect,
             backend: FsmBackendImpl::new(context)?
         };
         
         Ok(frontend)
     }
 
-    /// Build a new frontend for the FSM with a `FsmEventQueueVec` queue.
+    /// Build a new frontend for the FSM with a `FsmEventQueueVec` queue and no logging.
     #[cfg(feature="std")]
-    fn new(context: <Self::Fsm as FsmBackend>::Context) -> FsmResult<FsmFrontend<Self::Fsm, FsmEventQueueVec<Self::Fsm>>> {
+    fn new(context: <Self::Fsm as FsmBackend>::Context) -> FsmResult<FsmFrontend<Self::Fsm, FsmEventQueueVec<Self::Fsm>, InspectNull<Self::Fsm>>> {
         let frontend = FsmFrontend {
             queue: FsmEventQueueVec::new(),
-            backend: FsmBackendImpl::new(context)?
+            backend: FsmBackendImpl::new(context)?,
+            inspect: InspectNull::new()
         };
 
         Ok(frontend)

--- a/finny/src/fsm/fsm_impl.rs
+++ b/finny/src/fsm/fsm_impl.rs
@@ -1,4 +1,4 @@
-use crate::lib::*;
+use crate::{Inspect, lib::*};
 use crate::{FsmBackend, FsmEvent, FsmEventQueue, FsmResult, FsmStates};
 
 use super::FsmStateFactory;
@@ -51,13 +51,16 @@ impl<F: FsmBackend> Deref for FsmBackendImpl<F> {
 
 /// The frontend of a state machine which also includes environmental services like queues
 /// and inspection. The usual way to use the FSM.
-pub struct FsmFrontend<F, Q> where F: FsmBackend, Q: FsmEventQueue<F> {
+pub struct FsmFrontend<F, Q, I> 
+    where F: FsmBackend, Q: FsmEventQueue<F>, I: Inspect<F>
+{
+    pub backend: FsmBackendImpl<F>,
     pub queue: Q,
-    pub backend: FsmBackendImpl<F>
+    pub inspect: I    
 }
 
-impl<F, Q> FsmFrontend<F, Q>
-    where F: FsmBackend, Q: FsmEventQueue<F>
+impl<F, Q, I> FsmFrontend<F, Q, I>
+    where F: FsmBackend, Q: FsmEventQueue<F>, I: Inspect<F>
 {
     /// Start the FSM, initiates the transition to the initial state.
     pub fn start(&mut self) -> FsmResult<()> {
@@ -86,7 +89,9 @@ impl<F, Q> FsmFrontend<F, Q>
     }
 }
 
-impl<F, Q> Deref for FsmFrontend<F, Q> where F: FsmBackend, Q: FsmEventQueue<F> {
+impl<F, Q, I> Deref for FsmFrontend<F, Q, I>
+    where F: FsmBackend, Q: FsmEventQueue<F>, I: Inspect<F>
+{
     type Target = FsmBackendImpl<F>;
 
     fn deref(&self) -> &Self::Target {

--- a/finny/src/fsm/inspect.rs
+++ b/finny/src/fsm/inspect.rs
@@ -1,0 +1,53 @@
+use crate::{FsmBackend, FsmBackendImpl, FsmEvent, FsmRegionId, lib::*};
+
+pub trait Inspect<F> where F: FsmBackend {
+    type ContextDispatchEvent;
+
+    fn on_dispatch_event(&self, fsm: &FsmBackendImpl<F>, event: &FsmEvent<<F as FsmBackend>::Events>) -> Self::ContextDispatchEvent;
+    fn on_state_enter<State>(&self, fsm: &FsmBackendImpl<F>, ctx: &mut Self::ContextDispatchEvent) where <F as FsmBackend>::States: AsRef<State>;
+    fn on_state_exit<State>(&self, fsm: &FsmBackendImpl<F>, ctx: &mut Self::ContextDispatchEvent) where <F as FsmBackend>::States: AsRef<State>;
+    fn on_matched_transition<T>(&self, fsm: &FsmBackendImpl<F>, region: FsmRegionId, ctx: &mut Self::ContextDispatchEvent);
+    fn on_action(&self);
+    fn on_guard<T, Guard>(&self);
+}
+
+#[derive(Default)]
+pub struct InspectNull<F> {
+    _fsm: PhantomData<F>
+}
+
+impl<F> InspectNull<F> {
+    pub fn new() -> Self {
+        Self {
+            _fsm: PhantomData::default()
+        }
+    }
+}
+
+impl<F> Inspect<F> for InspectNull<F> where F: FsmBackend {
+    type ContextDispatchEvent = ();
+
+    fn on_dispatch_event(&self, _fsm: &FsmBackendImpl<F>, _event: &FsmEvent<<F as FsmBackend>::Events>) -> Self::ContextDispatchEvent {
+        ()
+    }
+
+    fn on_state_enter<State>(&self, _fsm: &FsmBackendImpl<F>, _ctx: &mut Self::ContextDispatchEvent) where <F as FsmBackend>::States: AsRef<State> {
+        
+    }
+
+    fn on_state_exit<State>(&self, _fsm: &FsmBackendImpl<F>, _ctx: &mut Self::ContextDispatchEvent) where <F as FsmBackend>::States: AsRef<State> {
+        
+    }
+
+    fn on_action(&self) {
+        
+    }
+
+    fn on_guard<T, Guard>(&self) {
+        
+    }
+
+    fn on_matched_transition<T>(&self, fsm: &FsmBackendImpl<F>, region: FsmRegionId, ctx: &mut Self::ContextDispatchEvent) {
+        
+    }
+}

--- a/finny/src/fsm/inspect.rs
+++ b/finny/src/fsm/inspect.rs
@@ -1,14 +1,19 @@
-use crate::{FsmBackend, FsmBackendImpl, FsmEvent, FsmRegionId, lib::*};
+use crate::{FsmBackend, FsmBackendImpl, FsmDispatchResult, FsmEvent, FsmRegionId, lib::*};
 
 pub trait Inspect<F> where F: FsmBackend {
-    type ContextDispatchEvent;
+    type CtxEvent;
+    type CtxTransition;
 
-    fn on_dispatch_event(&self, fsm: &FsmBackendImpl<F>, event: &FsmEvent<<F as FsmBackend>::Events>) -> Self::ContextDispatchEvent;
-    fn on_state_enter<State>(&self, fsm: &FsmBackendImpl<F>, ctx: &mut Self::ContextDispatchEvent) where <F as FsmBackend>::States: AsRef<State>;
-    fn on_state_exit<State>(&self, fsm: &FsmBackendImpl<F>, ctx: &mut Self::ContextDispatchEvent) where <F as FsmBackend>::States: AsRef<State>;
-    fn on_matched_transition<T>(&self, fsm: &FsmBackendImpl<F>, region: FsmRegionId, ctx: &mut Self::ContextDispatchEvent);
-    fn on_action(&self);
-    fn on_guard<T, Guard>(&self);
+    fn on_dispatch_event(&self, fsm: &FsmBackendImpl<F>, event: &FsmEvent<<F as FsmBackend>::Events>) -> Self::CtxEvent;
+    fn on_dispatched_event(&self, fsm: &FsmBackendImpl<F>, ctx: Self::CtxEvent, result: &FsmDispatchResult);
+    
+    fn on_guard<T>(&self, fsm: &FsmBackendImpl<F>, ctx: &mut Self::CtxEvent, guard_result: bool);
+
+    fn on_matched_transition<T>(&self, fsm: &FsmBackendImpl<F>, region: FsmRegionId, ctx: &mut Self::CtxEvent) -> Self::CtxTransition;
+    
+    fn on_state_enter<State>(&self, fsm: &FsmBackendImpl<F>, ctx: &mut Self::CtxTransition) where <F as FsmBackend>::States: AsRef<State>;
+    fn on_state_exit<State>(&self, fsm: &FsmBackendImpl<F>, ctx: &mut Self::CtxTransition) where <F as FsmBackend>::States: AsRef<State>;
+    fn on_action<T>(&self, fsm: &FsmBackendImpl<F>, ctx: &mut Self::CtxTransition);
 }
 
 #[derive(Default)]
@@ -25,29 +30,34 @@ impl<F> InspectNull<F> {
 }
 
 impl<F> Inspect<F> for InspectNull<F> where F: FsmBackend {
-    type ContextDispatchEvent = ();
+    type CtxEvent = ();
+    type CtxTransition = ();
 
-    fn on_dispatch_event(&self, _fsm: &FsmBackendImpl<F>, _event: &FsmEvent<<F as FsmBackend>::Events>) -> Self::ContextDispatchEvent {
+    fn on_dispatch_event(&self, _fsm: &FsmBackendImpl<F>, _event: &FsmEvent<<F as FsmBackend>::Events>) -> Self::CtxEvent {
         ()
     }
 
-    fn on_state_enter<State>(&self, _fsm: &FsmBackendImpl<F>, _ctx: &mut Self::ContextDispatchEvent) where <F as FsmBackend>::States: AsRef<State> {
+    fn on_dispatched_event(&self, fsm: &FsmBackendImpl<F>, ctx: Self::CtxEvent, result: &FsmDispatchResult) {
+
+    }
+
+    fn on_state_enter<State>(&self, _fsm: &FsmBackendImpl<F>, _ctx: &mut Self::CtxEvent) where <F as FsmBackend>::States: AsRef<State> {
         
     }
 
-    fn on_state_exit<State>(&self, _fsm: &FsmBackendImpl<F>, _ctx: &mut Self::ContextDispatchEvent) where <F as FsmBackend>::States: AsRef<State> {
+    fn on_state_exit<State>(&self, _fsm: &FsmBackendImpl<F>, _ctx: &mut Self::CtxEvent) where <F as FsmBackend>::States: AsRef<State> {
         
     }
 
-    fn on_action(&self) {
+    fn on_action<T>(&self, _fsm: &FsmBackendImpl<F>, _ctx: &mut Self::CtxEvent) {
         
     }
 
-    fn on_guard<T, Guard>(&self) {
+    fn on_guard<T>(&self, fsm: &FsmBackendImpl<F>, ctx: &mut Self::CtxEvent, guard_result: bool) {
         
     }
 
-    fn on_matched_transition<T>(&self, fsm: &FsmBackendImpl<F>, region: FsmRegionId, ctx: &mut Self::ContextDispatchEvent) {
-        
+    fn on_matched_transition<T>(&self, fsm: &FsmBackendImpl<F>, region: FsmRegionId, ctx: &mut Self::CtxEvent) -> Self::CtxTransition {
+        ()
     }
 }

--- a/finny/src/fsm/mod.rs
+++ b/finny/src/fsm/mod.rs
@@ -8,6 +8,7 @@ mod queue;
 mod states;
 mod transitions;
 mod tests_fsm;
+mod inspect;
 
 pub use self::events::*;
 pub use self::fsm_factory::*;
@@ -15,6 +16,7 @@ pub use self::fsm_impl::*;
 pub use self::queue::*;
 pub use self::states::*;
 pub use self::transitions::*;
+pub use self::inspect::*;
 
 use crate::lib::*;
 
@@ -38,11 +40,6 @@ pub trait FsmBackend where Self: Sized {
     /// A tagged union type with all the supported events.
     type Events;
 
-    /*
-    fn dispatch_event<Q>(backend: &mut FsmBackendImpl<Self>, event: &FsmEvent<Self::Events>, queue: &mut Q) -> FsmResult<()>
-        where Q: FsmEventQueue<Self>;
-        */
-
-    fn dispatch_event<Q>(frontend: &mut FsmFrontend<Self, Q>, event: &FsmEvent<Self::Events>) -> FsmResult<()>
-        where Q: queue::FsmEventQueue<Self>;
+    fn dispatch_event<Q, I>(frontend: &mut FsmFrontend<Self, Q, I>, event: &FsmEvent<Self::Events>) -> FsmResult<()>
+        where Q: queue::FsmEventQueue<Self>, I: Inspect<Self>;
 }

--- a/finny/src/fsm/mod.rs
+++ b/finny/src/fsm/mod.rs
@@ -29,6 +29,7 @@ pub enum FsmError {
     QueueOverCapacity
 }
 
+pub type FsmDispatchResult = FsmResult<()>;
 
 /// Finite State Machine backend. Handles the dispatching, the types are
 /// defined by the code generator.
@@ -40,6 +41,6 @@ pub trait FsmBackend where Self: Sized {
     /// A tagged union type with all the supported events.
     type Events;
 
-    fn dispatch_event<Q, I>(frontend: &mut FsmFrontend<Self, Q, I>, event: &FsmEvent<Self::Events>) -> FsmResult<()>
+    fn dispatch_event<Q, I>(frontend: &mut FsmFrontend<Self, Q, I>, event: &FsmEvent<Self::Events>) -> FsmDispatchResult
         where Q: queue::FsmEventQueue<Self>, I: Inspect<Self>;
 }

--- a/finny/src/fsm/states.rs
+++ b/finny/src/fsm/states.rs
@@ -7,7 +7,7 @@ pub trait FsmStates: FsmStateFactory {
     /// The enum type for all states that's used as the "current state" field in the FSM's backend.
     type StateKind: Clone + Copy + Debug + PartialEq;
     /// An array of current states for the machine, one for each region.
-    type CurrentState: Clone + Copy + Debug + Default;
+    type CurrentState: Clone + Copy + Debug + Default + AsMut<[FsmCurrentState<Self::StateKind>]>;
 }
 
 /// The current state of the FSM.
@@ -37,10 +37,12 @@ impl<TState> FsmStateFactory for TState where TState: Default {
     }
 }
 
+/// Retrieve a pair of states as immutable references. Used in state transitions.
 pub trait FsmStateTransitionAsRef<T1, T2> {
     fn as_state_transition_ref(&self) -> (&T1, &T2);
 }
 
+/// Retrieve a pair of states as mutable references. Used in state transitions.
 pub trait FsmStateTransitionAsMut<T1, T2> {
     fn as_state_transition_mut(&mut self) -> (&mut T1, &mut T2);
 }

--- a/finny/src/fsm/states.rs
+++ b/finny/src/fsm/states.rs
@@ -11,12 +11,21 @@ pub trait FsmStates: FsmStateFactory {
 }
 
 /// The current state of the FSM.
-#[derive(Copy, Clone, Debug, PartialEq)]
+#[derive(Copy, Clone, PartialEq)]
 pub enum FsmCurrentState<S> where S: Clone + Copy {
     /// The FSM is halted and has to be started using the `start()` method.
     Stopped,
     /// The FSM is in this state.
     State(S)
+}
+
+impl<S> Debug for FsmCurrentState<S> where S: Debug + Copy {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        match self {
+            FsmCurrentState::Stopped => f.write_str("Fsm::Stopped"),
+            FsmCurrentState::State(s) => s.fmt(f)
+        }
+    }
 }
 
 impl<S> Default for FsmCurrentState<S> where S: Clone + Copy {

--- a/finny/src/fsm/tests_fsm.rs
+++ b/finny/src/fsm/tests_fsm.rs
@@ -36,8 +36,8 @@ impl FsmBackend for TestFsm {
     type States = States;
     type Events = Events;
 
-    fn dispatch_event<Q>(_frontend: &mut crate::FsmFrontend<Self, Q>, _event: &crate::FsmEvent<Self::Events>) -> crate::FsmResult<()>
-        where Q: crate::FsmEventQueue<Self>
+    fn dispatch_event<Q, I>(_frontend: &mut crate::FsmFrontend<Self, Q, I>, _event: &crate::FsmEvent<Self::Events>) -> crate::FsmResult<()>
+        where Q: crate::FsmEventQueue<Self>, I: crate::Inspect<Self>
     {
         todo!()
     }

--- a/finny/src/fsm/transitions.rs
+++ b/finny/src/fsm/transitions.rs
@@ -1,6 +1,6 @@
 //! All of these traits will be implemented by the procedural code generator.
 
-use crate::{EventContext, FsmBackend, FsmEventQueue, FsmFrontend, FsmStateTransitionAsMut};
+use crate::{EventContext, FsmBackend, FsmCurrentState, FsmEvent, FsmEventQueue, FsmFrontend, FsmRegionId, FsmStateTransitionAsMut, FsmStates, Inspect};
 
 /// A state's entry and exit actions.
 pub trait FsmState<F: FsmBackend> {
@@ -9,12 +9,13 @@ pub trait FsmState<F: FsmBackend> {
     /// Action that is executed whenever this state is being exited.
     fn on_exit<'a, Q: FsmEventQueue<F>>(&mut self, context: &mut EventContext<'a, F, Q>);
 
-    fn execute_on_entry<Q>(frontend: &mut FsmFrontend<F, Q>) 
-        where Q: FsmEventQueue<F>, <F as FsmBackend>::States: AsMut<Self>
+    fn execute_on_entry<Q, I>(frontend: &mut FsmFrontend<F, Q, I>, region: FsmRegionId) 
+        where Q: FsmEventQueue<F>, I: Inspect<F>, <F as FsmBackend>::States: AsMut<Self>
     {
         let mut event_context = EventContext {
             context: &mut frontend.backend.context,
-            queue: &mut frontend.queue
+            queue: &mut frontend.queue,
+            region
         };
 
         let state: &mut Self = frontend.backend.states.as_mut();
@@ -22,18 +23,21 @@ pub trait FsmState<F: FsmBackend> {
         state.on_entry(&mut event_context);
     }
 
-    fn execute_on_exit<Q>(frontend: &mut FsmFrontend<F, Q>) 
-        where Q: FsmEventQueue<F>, <F as FsmBackend>::States: AsMut<Self>
+    fn execute_on_exit<Q, I>(frontend: &mut FsmFrontend<F, Q, I>, region: FsmRegionId) 
+        where Q: FsmEventQueue<F>, I: Inspect<F>, <F as FsmBackend>::States: AsMut<Self>
     {
         let mut event_context = EventContext {
             context: &mut frontend.backend.context,
-            queue: &mut frontend.queue
+            queue: &mut frontend.queue,
+            region
         };
 
         let state: &mut Self = frontend.backend.states.as_mut();
 
         state.on_exit(&mut event_context);
     }
+
+    fn fsm_state() -> <<F as FsmBackend>::States as FsmStates>::StateKind;
 }
 
 /// Check if this transition is allowed to be entered.
@@ -41,13 +45,29 @@ pub trait FsmTransitionGuard<F: FsmBackend, E> {
     /// Return a boolean value whether this transition is usable at the moment. The check shouln't mutate any structures.
     fn guard<'a, Q: FsmEventQueue<F>>(event: &E, context: &EventContext<'a, F, Q>) -> bool;
 
-    fn execute_guard<Q: FsmEventQueue<F>>(frontend: &mut FsmFrontend<F, Q>, event: &E) -> bool {
+    fn execute_guard<Q: FsmEventQueue<F>, I>(frontend: &mut FsmFrontend<F, Q, I>, event: &E, region: FsmRegionId) -> bool
+        where I: Inspect<F>
+    {
         let event_context = EventContext {
             context: &mut frontend.backend.context,
-            queue: &mut frontend.queue
+            queue: &mut frontend.queue,
+            region
         };
 
         Self::guard(event, &event_context)
+    }
+}
+
+
+pub trait FsmTransitionFsmStart<F: FsmBackend, TInitialState> {
+    fn execute_transition<Q: FsmEventQueue<F>, I >(frontend: &mut FsmFrontend<F, Q, I>, fsm_event: &FsmEvent<<F as FsmBackend>::Events>, region: FsmRegionId)
+        //where <F as FsmBackend>::States: AsMut<TInitialState>, I: Inspect<F>
+        where I: Inspect<F>, TInitialState: FsmState<F>, <F as FsmBackend>::States: AsMut<TInitialState>
+    {
+        <TInitialState>::execute_on_entry(frontend, region);
+        
+        let cs = frontend.backend.current_states.as_mut();
+        cs[region] = FsmCurrentState::State(<TInitialState>::fsm_state());
     }
 }
 
@@ -56,17 +76,44 @@ pub trait FsmTransitionAction<F: FsmBackend, E, TStateFrom, TStateTo> {
     /// This action is executed after the first state's exit event, and just before the second event's entry action. It can mutate both states.
     fn action<'a, Q: FsmEventQueue<F>>(event: &E, context: &mut EventContext<'a, F, Q>, from: &mut TStateFrom, to: &mut TStateTo);
 
-    fn execute_action_transition<Q: FsmEventQueue<F>>(frontend: &mut FsmFrontend<F, Q>, event: &E)
-        where <F as FsmBackend>::States: FsmStateTransitionAsMut<TStateFrom, TStateTo>
+
+    /*
+    fn execute_action_transition<Q: FsmEventQueue<F>, I>(frontend: &mut FsmFrontend<F, Q, I>, event: &E, region: FsmRegionId)
+        where <F as FsmBackend>::States: FsmStateTransitionAsMut<TStateFrom, TStateTo>, I: Inspect<F>
     {
         let mut event_context = EventContext {
             context: &mut frontend.backend.context,
-            queue: &mut frontend.queue
+            queue: &mut frontend.queue,
+            region
         };
 
         let states: (&mut TStateFrom, &mut TStateTo) = frontend.backend.states.as_state_transition_mut();
 
         Self::action(event, &mut event_context, states.0, states.1);
+    }
+    */
+
+    //fn execute_transition<Q: FsmEventQueue<F>, I>(frontend: &mut FsmFrontend<F, Q, I>, event: &FsmEvent<<F as FsmBackend>::Events>, region: FsmRegionId)
+    fn execute_transition<Q: FsmEventQueue<F>, I>(frontend: &mut FsmFrontend<F, Q, I>, event: &E, region: FsmRegionId)
+        where 
+            I: Inspect<F>,
+            <F as FsmBackend>::States: FsmStateTransitionAsMut<TStateFrom, TStateTo>
+    {
+        let mut event_context = EventContext {
+            context: &mut frontend.backend.context,
+            queue: &mut frontend.queue,
+            region
+        };
+
+        let states: (&mut TStateFrom, &mut TStateTo) = frontend.backend.states.as_state_transition_mut();
+
+        // todo: state exit
+            
+        Self::action(event, &mut event_context, states.0, states.1);
+
+        // todo: state enter
+
+        // todo: change current state
     }
 }
 
@@ -74,17 +121,35 @@ pub trait FsmTransitionAction<F: FsmBackend, E, TStateFrom, TStateTo> {
 pub trait FsmAction<F: FsmBackend, E, State> {
     /// This action is executed as part of an internal or self transition.
     fn action<'a, Q: FsmEventQueue<F>>(event: &E, context: &mut EventContext<'a, F, Q>, state: &mut State);
+    /// Is this a self transition which should trigger the state's exit and entry actions?
+    fn should_trigger_state_actions() -> bool;
 
-    fn execute_action<Q: FsmEventQueue<F>>(frontend: &mut FsmFrontend<F, Q>, event: &E)
-        where <F as FsmBackend>::States: AsMut<State>
+    fn execute_action<Q: FsmEventQueue<F>, I >(frontend: &mut FsmFrontend<F, Q, I>, event: &E, region: FsmRegionId)
+        where <F as FsmBackend>::States: AsMut<State>, I: Inspect<F>
     {
         let mut event_context = EventContext {
             context: &mut frontend.backend.context,
-            queue: &mut frontend.queue
+            queue: &mut frontend.queue,
+            region
         };
 
         let state: &mut State = frontend.backend.states.as_mut();
 
         Self::action(event, &mut event_context, state);
     }
+
+    //fn execute_transition<Q: FsmEventQueue<F>, I>(frontend: &mut FsmFrontend<F, Q, I>, event: &FsmEvent<<F as FsmBackend>::Events>, region: FsmRegionId)
+    fn execute_transition<Q: FsmEventQueue<F>, I>(frontend: &mut FsmFrontend<F, Q, I>, event: &E, region: FsmRegionId)
+        where I: Inspect<F> {
+            todo!("act")
+        }
 }
+
+/*
+pub trait FsmTransitionExecutor<F>
+    where F: FsmBackend
+{
+    fn execute_transition<Q: FsmEventQueue<F>, I>(frontend: &mut FsmFrontend<F, Q, I>, event: &<F as FsmBackend>::Events, region: FsmRegionId)
+        where I: Inspect<F>;
+}
+*/

--- a/finny/src/inspect_slog.rs
+++ b/finny/src/inspect_slog.rs
@@ -36,8 +36,10 @@ impl<F> Inspect<F> for InspectSlog
         }
     }
 
-    fn on_dispatched_event(&self, _fsm: &crate::FsmBackendImpl<F>, ctx: Self::CtxEvent, result: &FsmDispatchResult) {
-        info!(ctx.logger, "Finished the dispatching.");
+    fn on_dispatched_event(&self, fsm: &crate::FsmBackendImpl<F>, ctx: Self::CtxEvent, result: &FsmDispatchResult) {
+        let states = format!("{:?}",  fsm.current_states);
+        let result = format!("{:?}", result);
+        info!(ctx.logger, "Finished the dispatching. The new state is {states} and the result of the dispatch is {result}", states = &states, result = &result);
     }
 
     fn on_state_enter<State>(&self, _fsm: &crate::FsmBackendImpl<F>, ctx: &mut InspectSlogSubContext) where <F as FsmBackend>::States: AsRef<State> {

--- a/finny/src/inspect_slog.rs
+++ b/finny/src/inspect_slog.rs
@@ -1,0 +1,59 @@
+use slog::{OwnedKV, debug, info, o};
+
+use crate::{FsmBackend, FsmEvent, Inspect};
+use super::lib::*;
+
+pub struct InspectSlog {
+    logger: slog::Logger
+}
+
+pub struct InspectSlogEventContext {
+    logger: slog::Logger
+}
+
+impl InspectSlog {
+    pub fn new(logger: Option<slog::Logger>) -> Self {
+        InspectSlog {
+            logger: logger.unwrap_or(slog::Logger::root(slog::Discard, o!()))
+        }
+    }
+}
+
+impl<F> Inspect<F> for InspectSlog 
+    where F: FsmBackend, <F as FsmBackend>::Events: Debug
+{
+    type ContextDispatchEvent = InspectSlogEventContext;
+
+    fn on_dispatch_event(&self, fsm: &crate::FsmBackendImpl<F>, event: &FsmEvent<<F as FsmBackend>::Events>) -> InspectSlogEventContext {
+        
+        let log_event = format!("{:?}", event);
+        let log_current_states = format!("{:?}", fsm.current_states);
+        let kv = o!("event" => log_event, "current_states" => log_current_states);
+        info!(self.logger, "Dispatching the event."; &kv);
+        InspectSlogEventContext {
+            logger: self.logger.new(kv)
+        }
+    }
+
+    fn on_state_enter<State>(&self, _fsm: &crate::FsmBackendImpl<F>, ctx: &mut InspectSlogEventContext) where <F as FsmBackend>::States: AsRef<State> {
+        info!(ctx.logger, "Entering state {:?}", type_name::<State>());
+    }
+
+    fn on_state_exit<State>(&self, _fsm: &crate::FsmBackendImpl<F>, ctx: &mut InspectSlogEventContext) where <F as FsmBackend>::States: AsRef<State> {
+        info!(ctx.logger, "Exiting state {:?}", type_name::<State>());
+    }
+
+    fn on_action(&self) {
+        //todo!()
+    }
+
+    fn on_guard<T, Guard>(&self) {
+        //todo!()
+    }
+
+    fn on_matched_transition<T>(&self, fsm: &crate::FsmBackendImpl<F>, region: crate::FsmRegionId, ctx: &mut Self::ContextDispatchEvent) {
+        
+    }
+}
+
+

--- a/finny/src/inspect_slog.rs
+++ b/finny/src/inspect_slog.rs
@@ -1,13 +1,13 @@
 use slog::{OwnedKV, debug, info, o};
 
-use crate::{FsmBackend, FsmEvent, Inspect};
+use crate::{FsmBackend, FsmDispatchResult, FsmEvent, Inspect};
 use super::lib::*;
 
 pub struct InspectSlog {
     logger: slog::Logger
 }
 
-pub struct InspectSlogEventContext {
+pub struct InspectSlogSubContext {
     logger: slog::Logger
 }
 
@@ -22,37 +22,50 @@ impl InspectSlog {
 impl<F> Inspect<F> for InspectSlog 
     where F: FsmBackend, <F as FsmBackend>::Events: Debug
 {
-    type ContextDispatchEvent = InspectSlogEventContext;
+    type CtxEvent = InspectSlogSubContext;
+    type CtxTransition = InspectSlogSubContext;
 
-    fn on_dispatch_event(&self, fsm: &crate::FsmBackendImpl<F>, event: &FsmEvent<<F as FsmBackend>::Events>) -> InspectSlogEventContext {
+    fn on_dispatch_event(&self, fsm: &crate::FsmBackendImpl<F>, event: &FsmEvent<<F as FsmBackend>::Events>) -> InspectSlogSubContext {
         
         let log_event = format!("{:?}", event);
         let log_current_states = format!("{:?}", fsm.current_states);
         let kv = o!("event" => log_event, "current_states" => log_current_states);
         info!(self.logger, "Dispatching the event."; &kv);
-        InspectSlogEventContext {
+        InspectSlogSubContext {
             logger: self.logger.new(kv)
         }
     }
 
-    fn on_state_enter<State>(&self, _fsm: &crate::FsmBackendImpl<F>, ctx: &mut InspectSlogEventContext) where <F as FsmBackend>::States: AsRef<State> {
+    fn on_dispatched_event(&self, _fsm: &crate::FsmBackendImpl<F>, ctx: Self::CtxEvent, result: &FsmDispatchResult) {
+        info!(ctx.logger, "Finished the dispatching.");
+    }
+
+    fn on_state_enter<State>(&self, _fsm: &crate::FsmBackendImpl<F>, ctx: &mut InspectSlogSubContext) where <F as FsmBackend>::States: AsRef<State> {
         info!(ctx.logger, "Entering state {:?}", type_name::<State>());
     }
 
-    fn on_state_exit<State>(&self, _fsm: &crate::FsmBackendImpl<F>, ctx: &mut InspectSlogEventContext) where <F as FsmBackend>::States: AsRef<State> {
+    fn on_state_exit<State>(&self, _fsm: &crate::FsmBackendImpl<F>, ctx: &mut InspectSlogSubContext) where <F as FsmBackend>::States: AsRef<State> {
         info!(ctx.logger, "Exiting state {:?}", type_name::<State>());
     }
 
-    fn on_action(&self) {
-        //todo!()
+    fn on_action<T>(&self, _fsm: &crate::FsmBackendImpl<F>, ctx: &mut InspectSlogSubContext) {
+        info!(ctx.logger, "Executing the action for {transition}", transition = type_name::<T>());
     }
 
-    fn on_guard<T, Guard>(&self) {
-        //todo!()
+    fn on_guard<T>(&self, _fsm: &crate::FsmBackendImpl<F>, ctx: &mut Self::CtxEvent, guard_result: bool) {
+        let guard_result = format!("{}", guard_result);
+        let transition = type_name::<T>();
+        info!(ctx.logger, "The guard for {transition} evaluated to {guard_result}", transition = transition, guard_result = &guard_result);
     }
 
-    fn on_matched_transition<T>(&self, fsm: &crate::FsmBackendImpl<F>, region: crate::FsmRegionId, ctx: &mut Self::ContextDispatchEvent) {
-        
+    fn on_matched_transition<T>(&self, fsm: &crate::FsmBackendImpl<F>, region: crate::FsmRegionId, ctx: &mut InspectSlogSubContext) -> InspectSlogSubContext {
+        let transition = type_name::<T>();
+        let kv = o!("transition" => transition, "region" => region);
+        info!(ctx.logger, "Matched transition {transition} in region {region}", transition = transition, region = region);
+
+        InspectSlogSubContext {
+            logger: ctx.logger.new(kv)
+        }
     }
 }
 

--- a/finny/src/lib.rs
+++ b/finny/src/lib.rs
@@ -66,11 +66,16 @@
 pub mod decl;
 mod fsm;
 
+
+#[cfg(feature="inspect_slog")]
+pub mod inspect_slog;
+
 pub use fsm::*;
 
 extern crate finny_derive;
 extern crate derive_more;
 
+/// The procedural macro that will transform the builder function into the FSM.
 pub use finny_derive::finny_fsm;
 
 /// External bundled libraries to be used by the procedural macros.
@@ -90,9 +95,12 @@ mod lib {
    }
 
    pub use self::core::marker::{self, PhantomData};
-   pub use self::core::ops::{Deref, DerefMut};
+   pub use self::core::ops::{Deref, DerefMut, Index, IndexMut};
    pub use self::core::fmt::Debug;
    pub use self::core::result::Result;
+   pub use self::core::fmt;
+   pub use self::core::any::type_name;
+   pub use self::core::slice::SliceIndex;
 
    #[cfg(feature="std")]
    pub use std::collections::VecDeque;

--- a/finny_derive/Cargo.toml
+++ b/finny_derive/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "finny_derive"
-version = "0.1.0"
+version = "0.2.0"
 authors = ["Rudi Benkovic <rudi.benkovic@gmail.com>"]
 edition = "2018"
 repository = "https://github.com/hashmismatch/finny.rs"

--- a/finny_derive/src/codegen.rs
+++ b/finny_derive/src/codegen.rs
@@ -115,9 +115,17 @@ pub fn generate_fsm_code(fsm: &FsmFnInput, attr: TokenStream, input: TokenStream
         for (ty, _ev) in  fsm.fsm.events.iter() {
             variants.append_all(quote! { #ty ( #ty ),  });
         }
+
+        let mut derives = TokenStream::new();
+        if fsm.fsm.codegen_options.event_debug {
+            derives.append_all(quote! {
+                #[derive(Debug)]
+            });
+        }
         
         let evs = quote! {
             #[derive(finny::bundled::derive_more::From)]
+            #derives
             pub enum #event_enum_ty {
                 #variants
             }
@@ -143,6 +151,8 @@ pub fn generate_fsm_code(fsm: &FsmFnInput, attr: TokenStream, input: TokenStream
                         let state = s.state.get_fsm_state()?;
                         let event_ty = &s.event.get_event()?.ty;
 
+                        let is_self_transition = if let FsmTransitionType::SelfTransition(_) = &transition.ty { true } else { false };
+
                         if let Some(ref guard) = s.action.guard {
                             let remap = remap_closure_inputs(&guard.inputs, vec![
                                 quote! { event }, quote! { context }
@@ -164,29 +174,46 @@ pub fn generate_fsm_code(fsm: &FsmFnInput, attr: TokenStream, input: TokenStream
 
                             q.append_all(g);
                         }
-
-                        if let Some(ref action) = s.action.action {
+                        
+                        let action_body = if let Some(ref action) = s.action.action {
                             let remap = remap_closure_inputs(&action.inputs, vec![
                                 quote! { event }, quote! { context }, quote! { state }
                             ].as_slice())?;
 
-                            let body = &action.body;                     
-
-                            let state_ty = &state.ty;
                             let body = &action.body;
-                            let a = quote! {
-                                impl #fsm_generics_impl finny::FsmAction<#fsm_ty #fsm_generics_type, #event_ty, #state_ty, > for #ty #fsm_generics_where {
-                                    fn action<'a, Q>(event: & #event_ty , context: &mut finny::EventContext<'a, #fsm_ty #fsm_generics_type, Q >, state: &mut #state_ty)
-                                        where Q: finny::FsmEventQueue<#fsm_ty #fsm_generics_type>
-                                    {
-                                        #remap
-                                        { #body }
-                                    }
-                                }
-                            };
+                            
+                            quote! { 
+                                #remap
+                                { #body }
+                            }
+                        } else {
+                            TokenStream::new()
+                        };
 
-                            q.append_all(a);
-                        }
+                        let state_ty = &state.ty;
+                        q.append_all(quote! {
+                            impl #fsm_generics_impl finny::FsmAction<#fsm_ty #fsm_generics_type, #event_ty, #state_ty > for #ty #fsm_generics_where {
+                                fn action<'a, Q>(event: & #event_ty , context: &mut finny::EventContext<'a, #fsm_ty #fsm_generics_type, Q >, state: &mut #state_ty)
+                                    where Q: finny::FsmEventQueue<#fsm_ty #fsm_generics_type>
+                                {
+                                    #action_body
+                                }
+
+                                fn should_trigger_state_actions() -> bool {
+                                    #is_self_transition
+                                }
+                            }
+                        });
+                    },
+                    FsmTransitionType::StateTransition(s @ FsmStateTransition { state_from: FsmTransitionState::None, .. }) => {
+                        let initial_state_ty = &s.state_to.get_fsm_state()?.ty;
+
+                        q.append_all(quote! {
+                            impl #fsm_generics_impl finny::FsmTransitionFsmStart<#fsm_ty #fsm_generics_type, #initial_state_ty > for #ty #fsm_generics_where {
+
+                            }
+                        });
+
                     },
                     FsmTransitionType::StateTransition(s) => {
 
@@ -214,33 +241,39 @@ pub fn generate_fsm_code(fsm: &FsmFnInput, attr: TokenStream, input: TokenStream
                             q.append_all(g);
                         }
 
-                        if let Some(ref action) = s.action.action {
-                            let event_ty = &s.event.get_event()?.ty;
-                            let state_from = s.state_from.get_fsm_state()?;
-                            let state_to = s.state_to.get_fsm_state()?;                    
-
+                        let action_body = if let Some(ref action) = s.action.action {
                             let remap = remap_closure_inputs(&action.inputs, vec![
                                 quote! { event }, quote! { context }, quote! { from }, quote! { to }
                             ].as_slice())?;
 
-                            let body = &action.body;                     
-
-                            let state_from_ty = &state_from.ty;
-                            let state_to_ty = &state_to.ty;
                             let body = &action.body;
-                            let a = quote! {
-                                impl #fsm_generics_impl finny::FsmTransitionAction<#fsm_ty #fsm_generics_type, #event_ty, #state_from_ty, #state_to_ty> for #ty #fsm_generics_where {
-                                    fn action<'a, Q>(event: & #event_ty , context: &mut finny::EventContext<'a, #fsm_ty #fsm_generics_type, Q >, from: &mut #state_from_ty, to: &mut #state_to_ty)
-                                        where Q: finny::FsmEventQueue<#fsm_ty #fsm_generics_type>
-                                    {
-                                        #remap
-                                        { #body }
-                                    }
-                                }
-                            };
 
-                            q.append_all(a);
-                        }
+                            quote! {
+                                #remap
+                                { #body }
+                            }
+                        } else {
+                            TokenStream::new()
+                        };
+
+                        let event_ty = &s.event.get_event()?.ty;
+                        let state_from = s.state_from.get_fsm_state()?;
+                        let state_to = s.state_to.get_fsm_state()?;
+                        
+                        let state_from_ty = &state_from.ty;
+                        let state_to_ty = &state_to.ty;
+
+                        let a = quote! {
+                            impl #fsm_generics_impl finny::FsmTransitionAction<#fsm_ty #fsm_generics_type, #event_ty, #state_from_ty, #state_to_ty> for #ty #fsm_generics_where {
+                                fn action<'a, Q>(event: & #event_ty , context: &mut finny::EventContext<'a, #fsm_ty #fsm_generics_type, Q >, from: &mut #state_from_ty, to: &mut #state_to_ty)
+                                    where Q: finny::FsmEventQueue<#fsm_ty #fsm_generics_type>
+                                {
+                                    #action_body
+                                }
+                            }
+                        };
+
+                        q.append_all(a);
                     }
                 }
                 
@@ -287,8 +320,8 @@ pub fn generate_fsm_code(fsm: &FsmFnInput, attr: TokenStream, input: TokenStream
                     };
 
                     match event {
-                        crate::parse::FsmTransitionEvent::Start => quote! { finny::FsmEvent::Start },
-                        crate::parse::FsmTransitionEvent::Stop => quote ! { finny::FsmEvent::Stop },
+                        crate::parse::FsmTransitionEvent::Start => quote! { ev @ finny::FsmEvent::Start },
+                        crate::parse::FsmTransitionEvent::Stop => quote ! { ev @ finny::FsmEvent::Stop },
                         crate::parse::FsmTransitionEvent::Event(ref ev) => {
                             let kind = &ev.ty;
                             quote! { finny::FsmEvent::Event(#event_enum_ty::#kind(ref ev)) }
@@ -296,6 +329,7 @@ pub fn generate_fsm_code(fsm: &FsmFnInput, attr: TokenStream, input: TokenStream
                     }
                 };
 
+                /*
                 let state_from_action = {
                     let state = match &transition.ty {                    
                         FsmTransitionType::SelfTransition(s) => Some(&s.state),
@@ -307,13 +341,15 @@ pub fn generate_fsm_code(fsm: &FsmFnInput, attr: TokenStream, input: TokenStream
                         Some(FsmTransitionState::State(st)) => {
                             let ty = &st.ty;
                             quote! {
-                                <#ty>::execute_on_exit(frontend);
+                                <#ty>::execute_on_exit(frontend, #region_id);
                             }
                         },
                         _ => TokenStream::new()
                     }
                 };
+                */
 
+                /*
                 let state_to_action = {
                     let state = match &transition.ty {                    
                         FsmTransitionType::SelfTransition(s) => Some(&s.state),
@@ -325,13 +361,15 @@ pub fn generate_fsm_code(fsm: &FsmFnInput, attr: TokenStream, input: TokenStream
                         Some(FsmTransitionState::State(st)) => {
                             let ty = &st.ty;
                             quote! {
-                                <#ty>::execute_on_entry(frontend);
+                                <#ty>::execute_on_entry(frontend, #region_id);
                             }
                         },
                         _ => TokenStream::new()
                     }
                 };
+                */
 
+                /*
                 let current_state_update = {
                     match &transition.ty {
                         FsmTransitionType::InternalTransition(_) | FsmTransitionType::SelfTransition(_) => TokenStream::new(),
@@ -352,6 +390,7 @@ pub fn generate_fsm_code(fsm: &FsmFnInput, attr: TokenStream, input: TokenStream
                         }
                     }
                 };
+                */
                 
                 let guard = {
                     let has_guard = match &transition.ty {
@@ -365,32 +404,38 @@ pub fn generate_fsm_code(fsm: &FsmFnInput, attr: TokenStream, input: TokenStream
 
                     if has_guard {
                         quote! {
-                            if <#transition_ty>::execute_guard(frontend, ev)
+                            if <#transition_ty>::execute_guard(frontend, ev, #region_id)
                         }
                     } else {
                         TokenStream::new()
                     }
                 };
 
+                /*
                 let event_action = {
                     match &transition.ty {
                         FsmTransitionType::InternalTransition(FsmStateAction { action: EventGuardAction { action: Some(_), ..}, .. }) |
                         FsmTransitionType::SelfTransition(FsmStateAction { action: EventGuardAction { action: Some(_), ..}, .. }) => {
                             quote! {
-                                <#transition_ty>::execute_action(frontend, ev);
+                                <#transition_ty>::execute_action(frontend, ev, #region_id);
                             }
                         },
                         FsmTransitionType::StateTransition(FsmStateTransition { action: EventGuardAction { action: Some(_), .. }, .. }) => {
                             quote! {
-                                <#transition_ty>::execute_action_transition(frontend, ev);
+                                <#transition_ty>::execute_action_transition(frontend, ev, #region_id);
                             }
                         },
                         _ => TokenStream::new()
                     }
                 };
+                */
                 
                 let m = quote! {
                     ( #match_state , #match_event ) #guard => {
+
+                        <#transition_ty>::execute_transition(frontend, ev, #region_id);
+
+                        /*
                         { #state_from_action }
 
                         { #event_action }
@@ -398,6 +443,7 @@ pub fn generate_fsm_code(fsm: &FsmFnInput, attr: TokenStream, input: TokenStream
                         { #state_to_action }
 
                         { #current_state_update }
+                        */
                     },
                 };
 
@@ -425,12 +471,14 @@ pub fn generate_fsm_code(fsm: &FsmFnInput, attr: TokenStream, input: TokenStream
                 type States = #states_store_ty;
                 type Events = #event_enum_ty;
 
-                fn dispatch_event<Q>(frontend: &mut finny::FsmFrontend<Self, Q>, event: &finny::FsmEvent<Self::Events>) -> finny::FsmResult<()>
-                    where Q: finny::FsmEventQueue<Self>
+                fn dispatch_event<Q, I>(frontend: &mut finny::FsmFrontend<Self, Q, I>, event: &finny::FsmEvent<Self::Events>) -> finny::FsmResult<()>
+                    where Q: finny::FsmEventQueue<Self>, I: finny::Inspect<Self>
                 {
-                    use finny::{FsmTransitionGuard, FsmTransitionAction, FsmAction, FsmState};
+                    use finny::{FsmTransitionGuard, FsmTransitionAction, FsmAction, FsmState, FsmTransitionFsmStart};
 
                     let mut transition_misses = 0;
+
+                    let mut inspect_ctx = frontend.inspect.on_dispatch_event(&frontend.backend, event);
                     
                     #regions
 
@@ -476,6 +524,10 @@ pub fn generate_fsm_code(fsm: &FsmFnInput, attr: TokenStream, input: TokenStream
 
                     fn on_exit<'a, Q: finny::FsmEventQueue<#fsm_ty #fsm_generics_type>>(&mut self, context: &mut finny::EventContext<'a, #fsm_ty #fsm_generics_type, Q>) {
                         #on_exit
+                    }
+
+                    fn fsm_state() -> #states_enum_ty {
+                        #states_enum_ty :: #ty
                     }
                 }
 

--- a/finny_derive/src/parse.rs
+++ b/finny_derive/src/parse.rs
@@ -11,7 +11,7 @@ pub struct FsmFnInput {
     pub fsm: ValidatedFsm,
 }
 
-#[derive(Debug)]
+#[derive(Debug, Clone)]
 pub struct FsmFnBase {
     pub context_ty: syn::Type,
     pub fsm_ty: syn::Type,
@@ -254,8 +254,8 @@ pub struct EventGuardAction{
 
 impl FsmDeclarations {
     pub fn parse(base: &FsmFnBase, input_fn: &ItemFn, blocks: &Vec<FsmBlock>) -> syn::Result<ValidatedFsm> {
-        let mut parser = FsmParser::new();
-        parser.parse(base, input_fn, blocks)?;
+        let mut parser = FsmParser::new(base.clone());
+        parser.parse(input_fn, blocks)?;
         return parser.validate(input_fn);
     }
 }

--- a/finny_derive/src/parse.rs
+++ b/finny_derive/src/parse.rs
@@ -3,12 +3,12 @@ use std::collections::{HashMap, HashSet};
 use proc_macro2::{Span, TokenStream};
 use syn::{Error, Expr, ExprMethodCall, GenericArgument, ItemFn, parse::{self, Parse, ParseStream}, spanned::Spanned};
 
-use crate::{parse_blocks::{FsmBlock, decode_blocks, get_generics, get_method_receiver_ident}, parse_fsm::FsmParser, utils::{assert_no_generics, get_closure, to_field_name}};
+use crate::{parse_blocks::{FsmBlock, decode_blocks, get_generics, get_method_receiver_ident}, parse_fsm::{FsmCodegenOptions, FsmParser}, utils::{assert_no_generics, get_closure, to_field_name}};
 
 
 pub struct FsmFnInput {
     pub base: FsmFnBase,
-    pub fsm: ValidatedFsm
+    pub fsm: ValidatedFsm,
 }
 
 #[derive(Debug)]
@@ -134,6 +134,7 @@ pub struct FsmDeclarations {
 
 #[derive(Debug)]
 pub struct ValidatedFsm {
+    pub codegen_options: FsmCodegenOptions,
     pub regions: Vec<FsmRegion>,
     pub states: HashMap<syn::Type, FsmState>,
     pub events: HashMap<syn::Type, FsmEvent>

--- a/finny_derive/src/validation.rs
+++ b/finny_derive/src/validation.rs
@@ -4,7 +4,7 @@ use petgraph::{Graph, graph::NodeIndex, visit::Dfs};
 use proc_macro2::Span;
 use syn::spanned::Spanned;
 
-use crate::{parse::{FsmDeclarations, FsmRegion, ValidatedFsm}, utils::tokens_to_string};
+use crate::{parse::{FsmDeclarations, FsmRegion, ValidatedFsm}, parse_fsm::FsmCodegenOptions, utils::tokens_to_string};
 
 #[derive(Debug)]
 struct TypeNode {
@@ -12,7 +12,7 @@ struct TypeNode {
     region: Option<usize>
 }
 
-pub fn create_regions(decl: FsmDeclarations) -> syn::Result<ValidatedFsm> {
+pub fn create_regions(decl: FsmDeclarations, options: FsmCodegenOptions) -> syn::Result<ValidatedFsm> {
     let mut graph = Graph::new();
     let mut nodes = HashMap::new();
 
@@ -101,6 +101,7 @@ pub fn create_regions(decl: FsmDeclarations) -> syn::Result<ValidatedFsm> {
     Ok(ValidatedFsm {
         events: decl.events,
         states: decl.states,
-        regions
+        regions,
+        codegen_options: options
     })
 }

--- a/finny_nostd_tests/src/main.rs
+++ b/finny_nostd_tests/src/main.rs
@@ -1,7 +1,7 @@
 #![no_std]
 #![no_main]
 
-use finny::{finny_fsm, FsmFactory, FsmEventQueueArray};
+use finny::{finny_fsm, FsmFactory, FsmEventQueueArray, InspectNull};
 use finny::decl::{FsmBuilder, BuiltFsm};
 use heapless::consts::*;
 
@@ -15,8 +15,9 @@ pub extern "C" fn main(_argc: isize, _argv: *const *const u8) -> isize {
 
     {
         let ctx = StateMachineContext::default();
-        let queue = FsmEventQueueArray::<_, [_; 16]>::new();
-        let mut fsm = StateMachine::new_with(ctx, queue).unwrap();
+        let queue = FsmEventQueueArray::<_, [_; 16]>::new(); 
+        let inspect = InspectNull::new();
+        let mut fsm = StateMachine::new_with(ctx, queue, inspect).unwrap();
         fsm.start().unwrap();
     }
 

--- a/finny_tests/Cargo.toml
+++ b/finny_tests/Cargo.toml
@@ -3,6 +3,9 @@ name = "finny_tests"
 version = "0.1.0"
 authors = ["Rudi Benkovic <rudi.benkovic@gmail.com>"]
 publish = false
+edition = "2018"
 
 [dependencies]
 finny = { path = "../finny/" }
+slog = "2.7.0"
+slog-term = "2.6.0"


### PR DESCRIPTION
Simplified the code generation by moving more dispatch code into traits instead of being in the bowels of `codegen.rs`.

Added the inspection trait to the frontend and a `slog` implementation.

Implements #9 